### PR TITLE
Add docs build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/moead-framework/framework/branch/master/graph/badge.svg?token=J7MAU5E6BB)](https://codecov.io/gh/moead-framework/framework)
 [![PyPI](https://img.shields.io/pypi/v/moead-framework)](https://pypi.org/project/moead-framework/)
 [![GitHub](https://img.shields.io/github/license/moead-framework/framework?style=flat)](https://github.com/moead-framework/framework/blob/master/LICENCE)
+[![build status](https://github.com/moead-framework/framework/workflows/Documentation/badge.svg?branch=master)](https://moead-framework.github.io/framework/html/index.html)
 
 This python package *moead-framework* is a modular framework for multi-objective evolutionary algorithms by decomposition. 
 The goal  is to provide a modular framework for scientists and researchers interested in 


### PR DESCRIPTION
A 'docs' build-status badge that links to the documentation is common
with readthedocs-supported documentation. Since the documentation in
this repository is hosted differently, this badge basically provides
the same functionality: a quick way to see if the documentation has
successfully built and a direct link to where it is hosted.