### PR TITLE
Improve spelling/grammar in documentation

### DIFF
--- a/docs/main_components.rst
+++ b/docs/main_components.rst
@@ -18,7 +18,7 @@ __________________________________________
 You can find examples of file instances for combinatorial problems
 in this repository https://github.com/moead-framework/data/tree/master/problem.
 
-.. note:: You can implement your own problem by following :ref:`this tutoriel<tuto-problem>`.
+.. note:: You can implement your own problem by following :ref:`this tutorial<tuto-problem>`.
 
 
 Solution
@@ -58,7 +58,7 @@ For numerical problems
    moead_framework.algorithm.numerical.moead.Moead
 
 
-.. note:: You can implement your own algorithm by following :ref:`this tutoriel<tuto-algo>`.
+.. note:: You can implement your own algorithm by following :ref:`this tutorial<tuto-algo>`.
 
 
 Aggregation functions

--- a/docs/tuto.rst
+++ b/docs/tuto.rst
@@ -9,10 +9,10 @@ Implement your own problem
 To make your problem compliant with the framework, your problem class has to extend the class :class:`moead_framework.problem.Problem`
 and implement the following 3 required functions :
 
-- the fitness function :code:`f(function_id, solution)` has 2 required parameters. The function must returns the objective value of the solution
-  for the objective function_id in parameter.
+- the fitness function :code:`f(function_id, solution)` has 2 required parameters. The function must return the objective value of the given ``solution``
+  for the objective specified by ``function_id``.
 
-  .. note:: For compatibility with existing components, problems should be converted to minimization problems.
+.. note:: For compatibility with existing components, problems should be converted to minimization problems.
 
 .. code-block:: python
     
@@ -22,12 +22,12 @@ and implement the following 3 required functions :
 
 
 
-- The function :code:`generate_solution(array, evaluate)` generates a solution. A solution is a :class:`moead_framework.solution.one_dimensional_dolution.OneDimensionSolution` object that contains the representation of the solution in the `solution` attribute, and all fitness values in the `F` attribute.
+- The function :code:`generate_solution(array, evaluate)` generates a solution. A solution is a :class:`moead_framework.solution.one_dimensional_dolution.OneDimensionSolution` object that contains the representation of the solution in the ``solution`` attribute, and all fitness values in the ``F`` attribute.
  
- .. note:: All components of the framework available in this version are only compatible with OneDimensionSolution. If you want to manage new types of solutions, you have to adapt other components of the framework.
+.. note:: All components of the framework available in this version are only compatible with OneDimensionSolution. If you want to manage new types of solutions, you have to adapt other components of the framework.
  
- The function :code:`generate_solution(array, evaluate)` takes as parameter the representation of the function and the boolean :code:`evaluate`
- that determine if the solution object should save the fitness, the default value must be "True".
+The function :code:`generate_solution(array, evaluate)` takes as parameter ``array`` the representation of the solution and the boolean :code:`evaluate`
+that determine if the solution object should save the fitness, the default value must be ``True``.
 
 .. code-block:: python
     
@@ -88,7 +88,7 @@ If you want to manage the way to use all these components, you have to create
 a new algorithm by extending an available algorithm. Examples are available in this repository : https://github.com/moead-framework/framework/tree/master/moead_framework/algorithm.
 
 An example is the implementation of MOEA/D-DE :cite:`moead_de` in the class :class:`moead_framework.algorithm.combinatorial.moead_delta_nr` that extends **Moead** to rewrite the
-function `update_solutions()` and adds two new parameters.
+function ``update_solutions()`` and adds two new parameters.
 
 
 Manage the reproducibility of results

--- a/docs/tuto.rst
+++ b/docs/tuto.rst
@@ -6,13 +6,13 @@ Tutorials
 .. _tuto-problem:
 Implement your own problem
 --------------------------------------
-To make your problem compliant with the framework, your problem class have to extend the class :class:`moead_framework.problem.Problem` 
-and also implement the 3 required functions : 
+To make your problem compliant with the framework, your problem class has to extend the class :class:`moead_framework.problem.Problem`
+and implement the following 3 required functions :
 
-- the fitness function :code:`f(function_id, solution)` has 2 required parameters. The function must returns the objectif value of the solution 
+- the fitness function :code:`f(function_id, solution)` has 2 required parameters. The function must returns the objective value of the solution
   for the objective function_id in parameter.
 
-  .. note:: For a better compatibility with components, problems should be converted in minimization problems.
+  .. note:: For compatibility with existing components, problems should be converted to minimization problems.
 
 .. code-block:: python
     
@@ -22,12 +22,12 @@ and also implement the 3 required functions :
 
 
 
-- The function :code:`generate_solution(array, evaluate)` allows to generate a solution. A solution is an object OneDimensionSolution that contains the representation of the solution in the attribute solution and all fitness values in the F attribute. 
+- The function :code:`generate_solution(array, evaluate)` generates a solution. A solution is a :class:`moead_framework.solution.one_dimensional_dolution.OneDimensionSolution` object that contains the representation of the solution in the `solution` attribute, and all fitness values in the `F` attribute.
  
- .. note:: All components of the framework available in this version are only compatible with OneDimensionSolution. If you want manage new type of solutions, you have to adapt other components of the framework. 
+ .. note:: All components of the framework available in this version are only compatible with OneDimensionSolution. If you want to manage new types of solutions, you have to adapt other components of the framework.
  
- The function :code:`generate_solution(array, evaluate)` takes in parameter the representation of the function and the boolean :code:`evaluate` 
- that determine if the solution save the fitness, the default value must be "True".
+ The function :code:`generate_solution(array, evaluate)` takes as parameter the representation of the function and the boolean :code:`evaluate`
+ that determine if the solution object should save the fitness, the default value must be "True".
 
 .. code-block:: python
     
@@ -43,7 +43,7 @@ and also implement the 3 required functions :
             return x
   
 
-- The function :code:`generate_random_solution(evaluate)` generates a solution **randomly** in the same way than the previous function.
+- The function :code:`generate_random_solution(evaluate)` generates a solution **randomly** in the same way as the previous function.
 
 .. code-block:: python
 
@@ -57,8 +57,8 @@ Implement your own algorithm
 --------------------------------------------------------------------
 
 All components are set with default values to implement the first version of **MOEA/D**.
-You can customize each algorithms of the framework with your own
-components that you can set in parameter of the algorithm contructor.
+You can customize each algorithm in the framework with your own
+components that you can set as parameter of the algorithm contructor.
 
 Example for :class:`moead_framework.algorithm.combinatorial.moead` :
 
@@ -81,14 +81,14 @@ Example for :class:`moead_framework.algorithm.combinatorial.moead` :
               sps_strategy=SpsAllSubproblems,
               offspring_generator=OffspringGeneratorGeneric
               )
-    
-    
 
-If you want manage the way to use all this components, you have to create
+
+
+If you want to manage the way to use all these components, you have to create
 a new algorithm by extending an available algorithm. Examples are available in this repository : https://github.com/moead-framework/framework/tree/master/moead_framework/algorithm.
 
-For example with the implementation of MOEA/D-DE :cite:`moead_de` in the class :class:`moead_framework.algorithm.combinatorial.moead_delta_nr` that extends **Moead** to rewrite the 
-function update_solutions() and add two new parameters. 
+An example is the implementation of MOEA/D-DE :cite:`moead_de` in the class :class:`moead_framework.algorithm.combinatorial.moead_delta_nr` that extends **Moead** to rewrite the
+function `update_solutions()` and adds two new parameters.
 
 
 Manage the reproducibility of results
@@ -96,9 +96,9 @@ Manage the reproducibility of results
 
 Reproducibility of results is a major principle for scientific research.
 The feature used here is not specific to the framework but
-can be used for every python project that uses the random and numpy modules.
+can be used for every python project that uses the `numpy` and built-in `random` modules.
 
-Because the framework uses the random and numpy modules, you can be sure
+Because the framework uses the `random` and `numpy` modules, you can be sure
 to have the same results by running the same script several times if you
 add the following instructions before initializing problems or algorithms:
 
@@ -112,7 +112,7 @@ add the following instructions before initializing problems or algorithms:
     np.random.seed(seed)
 
 
-You can find more information with the following links:
+You can find more information at the following links:
 
 - https://docs.python.org/3/library/random.html
 - https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html
@@ -125,7 +125,7 @@ You can easily save a set of solutions by using the function :code:`save_populat
 The function must be imported with : :code:`from moead_framework.tool.result import save_population`.
 
 
-If you want save all non-dominated solutions (attribute :code:`self.ep` in the algorithm) every 10 evaluations, you can use the checkpoint parameter of the function :code:`algorithm.run()` :
+If you want to save all non-dominated solutions (attribute :code:`self.ep` in the algorithm) every e.g. 10 evaluations, you can use the checkpoint parameter of the function :code:`algorithm.run()` :
 
 
 .. code-block:: python


### PR DESCRIPTION
Fixed a typo of 'tutoriel' -> 'tutorial' in `main_components.rst`, and fixed a all small grammar issues I could find in the `tuto.rst` tutorial page, keeping the meaning of the existing text as much the same as possible.