### PR TITLE
Reordering Problems in Library Reference Section

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,3 +8,4 @@ Library Reference
 
 	main_components
 	other_components
+	problems

--- a/docs/main_components.rst
+++ b/docs/main_components.rst
@@ -3,24 +3,6 @@
 Main components
 ===========================================
 
-Problems
-__________________________________________
-
-.. autosummary::
-   :nosignatures:
-   :toctree: moead_framework
-
-   moead_framework.problem.combinatorial.rmnk.Rmnk
-   moead_framework.problem.combinatorial.mubqp.Mubqp
-   moead_framework.problem.combinatorial.knapsack.KnapsackProblem
-   moead_framework.problem.numerical.zdt.Zdt1
-
-You can find examples of file instances for combinatorial problems
-in this repository https://github.com/moead-framework/data/tree/master/problem.
-
-.. note:: You can implement your own problem by following :ref:`this tutorial<tuto-problem>`.
-
-
 Solution
 __________________________________________
 

--- a/docs/main_components.rst
+++ b/docs/main_components.rst
@@ -18,7 +18,7 @@ __________________________________________
 You can find examples of file instances for combinatorial problems
 in this repository https://github.com/moead-framework/data/tree/master/problem.
 
-.. note:: You can implement your own problem by following :ref:`this tutoriel<tuto-problem>`.
+.. note:: You can implement your own problem by following :ref:`this tutorial<tuto-problem>`.
 
 
 Solution
@@ -58,7 +58,7 @@ For numerical problems
    moead_framework.algorithm.numerical.moead.Moead
 
 
-.. note:: You can implement your own algorithm by following :ref:`this tutoriel<tuto-algo>`.
+.. note:: You can implement your own algorithm by following :ref:`this tutorial<tuto-algo>`.
 
 
 Aggregation functions

--- a/docs/problems.rst
+++ b/docs/problems.rst
@@ -1,0 +1,33 @@
+.. _components:
+
+Problems
+===========================================
+
+.. note:: You can implement your own problem by following :ref:`this tutorial<tuto-problem>`.
+
+
+Combinatorial
+___________________________________________
+
+.. autosummary::
+   :nosignatures:
+   :toctree: moead_framework
+
+   moead_framework.problem.combinatorial.rmnk.Rmnk
+   moead_framework.problem.combinatorial.mubqp.Mubqp
+   moead_framework.problem.combinatorial.knapsack.KnapsackProblem
+
+You can find examples of file instances for combinatorial problems
+in this repository https://github.com/moead-framework/data/tree/master/problem.
+
+
+Numerical
+___________________________________________
+
+
+.. autosummary::
+   :nosignatures:
+   :toctree: moead_framework
+
+   moead_framework.problem.numerical.zdt.Zdt1
+


### PR DESCRIPTION
Fixes #37 if accepted, by creating a separate section on `Problems` in the Library Reference section of the documentation.

