### PR TITLE
Reference requirements.txt in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import setuptools
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+with open("requirements.txt", "r") as fh:
+    requirements = fh.read().splitlines()
 
 setuptools.setup(
     name="moead-framework",
@@ -13,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/moead-framework/framework",
     packages=setuptools.find_packages(),
-    install_requires=['numpy'],
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
By reading the contents of requirements.txt in the setup.py,
you avoid specifying the dependencies in two separate places.

This also fixes the issue that there was no minimum version
specified in the setup.py, while there was in requirements.txt

related: #10 