### PR TITLE
Refactor genetic operators

### DIFF
--- a/moead_framework/core/genetic_operator/abstract_operator.py
+++ b/moead_framework/core/genetic_operator/abstract_operator.py
@@ -6,12 +6,14 @@ class GeneticOperator(ABC):
     Abstract class to implement a new genetic Operator
     """
 
-    def __init__(self, solutions, **kwargs):
+    def __init__(
+        self,
+        solutions,
+    ):
         """
         Constructor of the genetic operator.
 
         :param solutions: list<list<integer>> list of solution's representation (In algorithms, it is represented by the attribute :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution.decision_vector` of the class :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution`)
-        :param kwargs: optional arguments for the genetic operator
         """
         self.solutions = solutions
 

--- a/moead_framework/core/genetic_operator/combinatorial/__init__.py
+++ b/moead_framework/core/genetic_operator/combinatorial/__init__.py
@@ -1,3 +1,5 @@
-from moead_framework.core.genetic_operator.combinatorial.cross_mut import CrossoverAndMutation
+from moead_framework.core.genetic_operator.combinatorial.cross_mut import (
+    CrossoverAndMutation,
+)
 from moead_framework.core.genetic_operator.combinatorial.crossover import Crossover
 from moead_framework.core.genetic_operator.combinatorial.mutation import BinaryMutation

--- a/moead_framework/core/genetic_operator/combinatorial/cross_mut.py
+++ b/moead_framework/core/genetic_operator/combinatorial/cross_mut.py
@@ -10,7 +10,8 @@ class CrossoverAndMutation(GeneticOperator):
     Require 2 solutions, run a crossover according to the number of points wanted and
     try to mutate each bit of the decision_vector with the predefined probability.
     """
-    def __init__(self, solutions, **kwargs):
+
+    def __init__(self, solutions, crossover_points=1, mutation_probability=None):
         """
         Constructor of the Crossover and Binary Mutation operator
 
@@ -18,16 +19,9 @@ class CrossoverAndMutation(GeneticOperator):
         :param crossover_points: {integer} the number of points for the crossover
         :param mutation_probability: {float} the probability (between 0 and 1) to mutate a bit in the decision_vector. The default value is the probability to mutate one bit of the decision_vector
         """
-        super().__init__(solutions, **kwargs)
-        if kwargs.get("crossover_points") is None:
-            self.crossover_points = 1
-        else:
-            self.crossover_points = int(kwargs.get("crossover_points"))
-
-        if kwargs.get("mutation_probability") is None:
-            self.mutation_probability = 1 / (len(self.solutions[0]))
-        else:
-            self.mutation_probability = float(kwargs.get("mutation_probability"))
+        super().__init__(solutions)
+        self.crossover_points = crossover_points
+        self.mutation_probability = mutation_probability
 
     def run(self):
         """
@@ -38,7 +32,11 @@ class CrossoverAndMutation(GeneticOperator):
 
         self.number_of_solution_is_correct(n=2)
 
-        child = Crossover(solutions=self.solutions, crossover_points=self.crossover_points).run()
-        child = BinaryMutation(solutions=[child], mutation_probability=self.mutation_probability).run()
+        child = Crossover(
+            solutions=self.solutions, crossover_points=self.crossover_points
+        ).run()
+        child = BinaryMutation(
+            solutions=[child], mutation_probability=self.mutation_probability
+        ).run()
 
         return child

--- a/moead_framework/core/genetic_operator/combinatorial/crossover.py
+++ b/moead_framework/core/genetic_operator/combinatorial/crossover.py
@@ -10,18 +10,15 @@ class Crossover(GeneticOperator):
     Require 2 solutions, run a crossover according to the number of points wanted.
     """
 
-    def __init__(self, solutions, **kwargs):
+    def __init__(self, solutions, crossover_points=1):
         """
         Constructor of the Crossover operator
 
         :param solutions: list<list<integer>> list of solution's representation (In algorithms, it is represented by the attribute :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution.decision_vector` of the class :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution`)
         :param crossover_points: {integer} the number of points for the crossover
         """
-        super().__init__(solutions, **kwargs)
-        if kwargs.get("crossover_points") is None:
-            self.crossover_points = 1
-        else:
-            self.crossover_points = int(kwargs.get("crossover_points"))
+        super().__init__(solutions)
+        self.crossover_points = int(crossover_points)
 
     def run(self):
         """
@@ -47,15 +44,15 @@ class Crossover(GeneticOperator):
         for i in range(self.crossover_points):
             last_i = i
             if i % 2 == 0:
-                child = np.append(child, solution1[current:list_of_points[i]])
+                child = np.append(child, solution1[current : list_of_points[i]])
             else:
-                child = np.append(child, solution2[current:list_of_points[i]])
+                child = np.append(child, solution2[current : list_of_points[i]])
 
             current = list_of_points[i]
 
         if last_i % 2 == 0:
-            child = np.append(child, solution2[list_of_points[-1]:])
+            child = np.append(child, solution2[list_of_points[-1] :])
         else:
-            child = np.append(child, solution1[list_of_points[-1]:])
+            child = np.append(child, solution1[list_of_points[-1] :])
 
         return child

--- a/moead_framework/core/genetic_operator/combinatorial/mutation.py
+++ b/moead_framework/core/genetic_operator/combinatorial/mutation.py
@@ -9,18 +9,17 @@ class BinaryMutation(GeneticOperator):
     Require only one solution. Try to mutate each bit of the decision_vector with a predefined probability.
     """
 
-    def __init__(self, solutions, **kwargs):
+    def __init__(self, solutions, mutation_probability=None):
         """
         Constructor of the Binary Mutation operator
 
         :param solutions: list<list<integer>> list of solution's representation (In algorithms, it is represented by the attribute :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution.decision_vector` of the class :class:`~moead_framework.solution.one_dimension_solution.OneDimensionSolution`)
         :param mutation_probability: {float} the probability (between 0 and 1) to mutate a bit in the decision_vector. The default value is the probability to mutate one bit of the decision_vector
         """
-        super().__init__(solutions, **kwargs)
-        if kwargs.get("mutation_probability") is None:
-            self.mutation_probability = 1 / (len(self.solutions[0]))
-        else:
-            self.mutation_probability = float(kwargs.get("mutation_probability"))
+        super().__init__(solutions)
+        proba = mutation_probability
+        default_proba = 1 / (len(self.solutions[0]))
+        self.mutation_probability = default_proba if proba is None else float(proba)
 
     def run(self):
         """

--- a/moead_framework/core/genetic_operator/numerical/__init__.py
+++ b/moead_framework/core/genetic_operator/numerical/__init__.py
@@ -1,3 +1,9 @@
-from moead_framework.core.genetic_operator.numerical.differential_evolution_crossover import DifferentialEvolutionCrossover
-from moead_framework.core.genetic_operator.numerical.moead_de_operators import MoeadDeOperators
-from moead_framework.core.genetic_operator.numerical.polynomial_mutation import PolynomialMutation
+from moead_framework.core.genetic_operator.numerical.differential_evolution_crossover import (
+    DifferentialEvolutionCrossover,
+)
+from moead_framework.core.genetic_operator.numerical.moead_de_operators import (
+    MoeadDeOperators,
+)
+from moead_framework.core.genetic_operator.numerical.polynomial_mutation import (
+    PolynomialMutation,
+)

--- a/moead_framework/core/genetic_operator/numerical/differential_evolution_crossover.py
+++ b/moead_framework/core/genetic_operator/numerical/differential_evolution_crossover.py
@@ -47,4 +47,3 @@ class DifferentialEvolutionCrossover(GeneticOperator):
         :return:
         """
         return [mini if x < mini else maxi if x > maxi else x for x in s]
-

--- a/moead_framework/core/genetic_operator/numerical/moead_de_operators.py
+++ b/moead_framework/core/genetic_operator/numerical/moead_de_operators.py
@@ -1,9 +1,12 @@
 import random
 import numpy as np
 from moead_framework.core.genetic_operator.abstract_operator import GeneticOperator
-from moead_framework.core.genetic_operator.numerical.differential_evolution_crossover import \
-    DifferentialEvolutionCrossover
-from moead_framework.core.genetic_operator.numerical.polynomial_mutation import PolynomialMutation
+from moead_framework.core.genetic_operator.numerical.differential_evolution_crossover import (
+    DifferentialEvolutionCrossover,
+)
+from moead_framework.core.genetic_operator.numerical.polynomial_mutation import (
+    PolynomialMutation,
+)
 
 
 class MoeadDeOperators(GeneticOperator):
@@ -25,13 +28,10 @@ class MoeadDeOperators(GeneticOperator):
         solution2 = self.solutions[1]
         solution3 = self.solutions[2]
 
-        child_cross = DifferentialEvolutionCrossover(solutions=[solution1,
-                                                                solution2,
-                                                                solution3]).run()
+        child_cross = DifferentialEvolutionCrossover(
+            solutions=[solution1, solution2, solution3]
+        ).run()
 
         child_mut = PolynomialMutation(solutions=[child_cross]).run()
 
         return child_mut
-
-
-

--- a/moead_framework/core/genetic_operator/numerical/polynomial_mutation.py
+++ b/moead_framework/core/genetic_operator/numerical/polynomial_mutation.py
@@ -19,7 +19,7 @@ class PolynomialMutation(GeneticOperator):
         self.number_of_solution_is_correct(n=1)
         solution = self.solutions[0]
 
-        return self.mutation(s=solution, rate=1/len(solution), n=len(solution))
+        return self.mutation(s=solution, rate=1 / len(solution), n=len(solution))
 
     def repair(self, s, mini=0, maxi=1):
         """
@@ -44,7 +44,12 @@ class PolynomialMutation(GeneticOperator):
         :return:
         """
         rand = random.uniform(0, 1)
-        return self.repair([s[x] if rand > rate else s[x] + self.sigma(n) * (maxi - (mini)) for x in range(len(s))])
+        return self.repair(
+            [
+                s[x] if rand > rate else s[x] + self.sigma(n) * (maxi - (mini))
+                for x in range(len(s))
+            ]
+        )
 
     def sigma(self, n):
         """

--- a/moead_framework/core/offspring_generator/offspring_generator.py
+++ b/moead_framework/core/offspring_generator/offspring_generator.py
@@ -22,19 +22,15 @@ class OffspringGeneratorGeneric(OffspringGenerator):
         for s in parents:
             parents_solutions.append(s.decision_vector)
 
-        if hasattr(self.algorithm, 'number_of_crossover_points'):
-            crossover_point = self.algorithm.number_of_crossover_points
-        else:
-            crossover_point = None
+        params = {"solutions": parents_solutions}
+        proba = 'mutation_probability'
+        
+        if hasattr(self.algorithm, "number_of_crossover_points"):
+            params["crossover_points"] = self.algorithm.number_of_crossover_points
 
-        if hasattr(self.algorithm, 'mutation_probability'):
-            mutation_probability = self.algorithm.mutation_probability
-        else:
-            mutation_probability = None
+        if hasattr(self.algorithm, proba):
+            params[proba] = self.algorithm.mutation_probability
 
-        y_sol = self.algorithm.genetic_operator(solutions=parents_solutions,
-                                                crossover_points=crossover_point,
-                                                mutation_probability=mutation_probability
-                                                ).run()
+        y_sol = self.algorithm.genetic_operator(**params).run()
 
         return self.algorithm.problem.evaluate(x=y_sol)


### PR DESCRIPTION
`**kwargs` could be avoided in genetic operators. 
Changed files have been formatted  with [black](https://github.com/psf/black) .
Validations are missing. But the idea is contained in the current PR.